### PR TITLE
Updated actions to support master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: Build and test
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - master
     paths:
       - "src/**"
       - "Cargo.*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release to GHCR
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches:
+      - main
+      - master
     paths:
       - "**"
       - "src/**"
@@ -68,6 +70,7 @@ jobs:
           draft: false
 
   artifact_release:
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     needs: build_signed_actor
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This will allow the build/release actions to run on the `master` or `main` branch.

You may also be interested in the Release action which will automatically publish this actor to github packages associated with this repository. This will require some setup on your end, but we have a guide in a blog post here: https://wasmcloud.com/blog/2022-05-23_ghcr-actions/